### PR TITLE
fix(v0.33.0): compatibility with task_tracker namespace and command toml format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to bkit-gemini will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Gemini CLI v0.33.0 Compatibility**: Updated task tracker tool names to use the required `task_tracker__` namespace (e.g., `task_tracker__tracker_create_task`) across 5 affected agents (`cto-lead`, `pdca-iterator`, `pm-lead`, `product-manager`, `qa-strategist`).
+- **Command TOML Parsing**: Removed legacy `[command]` table header and `name` field from 6 command files (`/simplify`, `/batch`, `/loop`, `/plan-plus`, `/pm-discovery`, `/output-style-setup`) to comply with v0.33.0 top-level key parsing requirements.
+
 ## [1.5.8] - 2026-03-11
 
 ### Added

--- a/agents/cto-lead.md
+++ b/agents/cto-lead.md
@@ -33,10 +33,10 @@ tools:
   - run_shell_command
   - google_web_search
   - web_fetch
-  - tracker_create_task
-  - tracker_update_task
-  - tracker_list_tasks
-  - tracker_visualize
+  - task_tracker__tracker_create_task
+  - task_tracker__tracker_update_task
+  - task_tracker__tracker_list_tasks
+  - task_tracker__tracker_visualize
 temperature: 0.4
 max_turns: 30
 timeout_mins: 15

--- a/agents/pdca-iterator.md
+++ b/agents/pdca-iterator.md
@@ -33,8 +33,8 @@ tools:
   - grep_search
   - glob
   - run_shell_command
-  - tracker_update_task
-  - tracker_get_task
+  - task_tracker__tracker_update_task
+  - task_tracker__tracker_get_task
 temperature: 0.4
 max_turns: 30
 timeout_mins: 15

--- a/agents/pm-lead.md
+++ b/agents/pm-lead.md
@@ -21,10 +21,10 @@ tools:
   - grep_search
   - run_shell_command
   - google_web_search
-  - tracker_create_task
-  - tracker_update_task
-  - tracker_list_tasks
-  - tracker_visualize
+  - task_tracker__tracker_create_task
+  - task_tracker__tracker_update_task
+  - task_tracker__tracker_list_tasks
+  - task_tracker__tracker_visualize
 temperature: 0.3
 max_turns: 50
 timeout_mins: 30

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -28,8 +28,8 @@ tools:
   - grep_search
   - google_web_search
   - web_fetch
-  - tracker_create_task
-  - tracker_list_tasks
+  - task_tracker__tracker_create_task
+  - task_tracker__tracker_list_tasks
 temperature: 0.6
 max_turns: 15
 timeout_mins: 10

--- a/agents/qa-strategist.md
+++ b/agents/qa-strategist.md
@@ -27,8 +27,8 @@ tools:
   - glob
   - grep_search
   - run_shell_command
-  - tracker_list_tasks
-  - tracker_visualize
+  - task_tracker__tracker_list_tasks
+  - task_tracker__tracker_visualize
 temperature: 0.3
 max_turns: 20
 timeout_mins: 10

--- a/commands/batch.toml
+++ b/commands/batch.toml
@@ -1,5 +1,3 @@
-[command]
-name = "batch"
 description = "Process multiple features in parallel"
 prompt = """
 @{extensionPath}/skills/batch/SKILL.md

--- a/commands/loop.toml
+++ b/commands/loop.toml
@@ -1,5 +1,3 @@
-[command]
-name = "loop"
 description = "Run a command on a recurring interval"
 prompt = """
 @{extensionPath}/skills/loop/SKILL.md

--- a/commands/output-style-setup.toml
+++ b/commands/output-style-setup.toml
@@ -1,5 +1,3 @@
-[command]
-name = "output-style-setup"
 description = "Install and configure bkit output styles"
 prompt = """
 @{extensionPath}/skills/output-style-setup/SKILL.md

--- a/commands/plan-plus.toml
+++ b/commands/plan-plus.toml
@@ -1,5 +1,3 @@
-[command]
-name = "plan-plus"
 description = "Brainstorming-Enhanced PDCA Planning"
 prompt = """
 @{extensionPath}/skills/plan-plus/SKILL.md

--- a/commands/pm-discovery.toml
+++ b/commands/pm-discovery.toml
@@ -1,5 +1,3 @@
-[command]
-name = "pm"
 description = "Run PM Agent Team analysis for product discovery"
 prompt = """
 @{extensionPath}/skills/pm-discovery/SKILL.md

--- a/commands/simplify.toml
+++ b/commands/simplify.toml
@@ -1,5 +1,3 @@
-[command]
-name = "simplify"
 description = "Review and simplify changed code"
 prompt = """
 @{extensionPath}/skills/simplify/SKILL.md


### PR DESCRIPTION
## Overview
This PR fixes compatibility issues introduced in Gemini CLI v0.33.0.

## Key Changes
1. **Agent Tool Namespace Fix**: 
   - Updated all task tracker tools to use the required 	ask_tracker__ namespace (e.g., 	ask_tracker__tracker_create_task).
   - Affected agents: cto-lead, pdca-iterator, pm-lead, product-manager, qa-strategist.

2. **Command TOML Format Update**:
   - Removed legacy [command] table header and 
ame field from 6 command files to comply with v0.33.0's top-level key parsing requirements.
   - Affected commands: /simplify, /batch, /loop, /plan-plus, /pm-discovery, /output-style-setup.

3. **Changelog**:
   - Added Unreleased section with compatibility fix details.

## Verification Results
- All agents now load without Invalid tool name errors.
- All commands now load without Skipping invalid command file errors.
- Verified via gemini extensions config bkit.